### PR TITLE
Docker pull latest version

### DIFF
--- a/muse.cwl.yaml
+++ b/muse.cwl.yaml
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 baseCommand: [/opt/bin/muse.py, -O, muse.vcf, -w, ./, --muse, MuSEv1.0rc]
 requirements:
   - class: "DockerRequirement"
-    dockerImageId: "opengenomics/muse:c039ffa"
+    dockerPull: "opengenomics/muse:latest"
 inputs:
   tumor:
     type: File


### PR DESCRIPTION
I'm thinking that it's useful to have the master branch have docker image versions of "latest". This makes it easy to develop and rebuild images, and to commit those fixes and have the version match docker hub.

Specific versions should be set when a tool/workflow is tagged in git (and therefore docker hub).